### PR TITLE
Add a special handling for fs_manifest key-value pair

### DIFF
--- a/qstat.c
+++ b/qstat.c
@@ -6453,7 +6453,7 @@ deal_with_q2_packet(struct qserver *server, char *rawpkt, int pktlen)
 			pkt += strlen(key) + 1;
 
 			// Find the value
-			end = strpbrk(pkt, "\\\n");
+			end = strpbrk(pkt, strcmp(key, "fs_manifest") ? "\\\n" : "\\");
 			if (NULL == end) {
 				// Last value
 				end = rawpkt + pktlen;


### PR DESCRIPTION
Some servers return fs_manifest key-value pair, which has it's value
split by newline, followed by a space. qstat breaks on such servers (at
least, it can't fetch the rules and players, because it treats newline
as beginning of player data, an unexpected data causes qstat to break
with error).

One such example is server run by my colleague, at 52.59.239.15:57131

Raw data from socket:

```
b'\xff\xff\xff\xffstatusResponse\n\\fs_cdn\\84.252.132.60:9000\\dmflags\\0\\fraglimit\\25\\timelimit\\15\\g_gametype\\4\\sv_privateClients\\0\\sv_hostname\\The Quake CTF (VQ3)\\sv_maxclients\\24\\sv_minRate\\0\\sv_maxRate\\30000\\sv_dlRate\\2000\\sv_minPing\\0\\sv_maxPing\\0\\sv_floodProtect\\0\\sv_allowDownload\\1\\sv_dlURL\\http://84.252.132.60:8000\\g_maxGameClients\\0\\sv_fps\\30\\server_gameplay\\VQ3\\version\\ioq3 1.36 linux-x86_64 Apr 23 2021\\com_gamename\\Quake3Arena\\com_protocol\\71\\mapname\\q3wcp18\\fs_manifest\\baseq3/pak100.pk3@2388798635@16506992\n baseq3/pak101.pk3@2206768903@2657563\n baseq3/pak102.pk3@2076841188@3024290\n baseq3/q3wcp18.pk3@2233822267@7704683\n cpma/z-cpma-pak152.pk3@3054920672@8135165\n linuxq3ademo-1.11-6.x86.gz.sh@857908472@49289300\n linuxq3apoint-1.32b-3.x86.run@296843703@30923961\n \\game\\CPMA\\gamename\\cpma\\gamedate\\Apr 03 2019\\gameversion\\1.52\\sv_arenas\\1\\Score_Time\\Warmup\\Score_Red\\0\\Score_Blue\\0\\Players_Blue\\1 \\GTV_CN\\1\\g_needpass\\0\\mode_current\\PUBCTF\n0 34 "UltraBloxX"\n'
```

Example of qstat run:

```
qstat -P -q3s 52.59.239.15:57131
ADDRESS           PLAYERS      MAP   RESPONSE TIME    NAME
52.59.239.15:57131    ERROR < baseq3/pak101.pk3@2206768903@2657563>
```

Following patch implements special handling for fs_manifest key, that ignores newline as a separator, while keeping all other parsing intact, so it fixes qstat to handle this server correctly, while it shouldn't break anything else.